### PR TITLE
fix: compatibility with later casbin patches

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-casbin==1.18.0
+casbin~=1.18
 redis==4.5.2


### PR DESCRIPTION
redis-watcher explicitly expects casbin 1.18.0, I think it should be compatible with patches to casbin 1.18.