### PR TITLE
feat: support redis version >= 5 in dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "License :: OSI Approved :: Apache Software License",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 casbin~=1.18
-redis==4.5.2
+redis>=4.5.2

--- a/tests/test_redis_watcher.py
+++ b/tests/test_redis_watcher.py
@@ -22,6 +22,10 @@ import redis
 from casbin_redis_watcher import WatcherOptions, new_watcher, new_publish_watcher
 
 
+REDIS_HOST: str = "localhost"
+REDIS_PORT: int = 6379
+
+
 def get_examples(path):
     examples_path = os.path.split(os.path.realpath(__file__))[0] + "/../examples/"
     return os.path.abspath(examples_path + path)
@@ -30,8 +34,8 @@ def get_examples(path):
 class TestConfig(TestCase):
     def test_watcher_init(self):
         test_option = WatcherOptions()
-        test_option.host = "localhost"
-        test_option.port = "6379"
+        test_option.host = REDIS_HOST
+        test_option.port = REDIS_PORT
         test_option.optional_update_callback = lambda event: print("update callback, event: {}".format(event))
         w = new_watcher(test_option)
         assert isinstance(w.sub_client, redis.client.PubSub)
@@ -39,8 +43,8 @@ class TestConfig(TestCase):
 
     def test_publish_watcher_init(self):
         test_option = WatcherOptions()
-        test_option.host = "localhost"
-        test_option.port = "6379"
+        test_option.host = REDIS_HOST
+        test_option.port = REDIS_PORT
         test_option.optional_update_callback = lambda event: print("update callback, event: {}".format(event))
         w = new_publish_watcher(test_option)
         assert w.sub_client is None
@@ -48,8 +52,8 @@ class TestConfig(TestCase):
 
     def test_watcher_init_without_callback(self):
         test_option = WatcherOptions()
-        test_option.host = "localhost"
-        test_option.port = "6379"
+        test_option.host = REDIS_HOST
+        test_option.port = REDIS_PORT
         w = new_watcher(test_option)
         assert isinstance(w.sub_client, redis.client.PubSub)
         assert isinstance(w.pub_client, redis.client.Redis)
@@ -63,8 +67,8 @@ class TestConfig(TestCase):
             print("callback_function, event: {}".format(event))
 
         test_option = WatcherOptions()
-        test_option.host = "localhost"
-        test_option.port = "6379"
+        test_option.host = REDIS_HOST
+        test_option.port = REDIS_PORT
         test_option.channel = "test"
         test_option.optional_update_callback = callback_function
         w = new_watcher(test_option)
@@ -88,8 +92,8 @@ class TestConfig(TestCase):
             print("callback_function, event: {}".format(event))
 
         test_option = WatcherOptions()
-        test_option.host = "localhost"
-        test_option.port = "6379"
+        test_option.host = REDIS_HOST
+        test_option.port = REDIS_PORT
         test_option.channel = "test"
         test_option.optional_update_callback = callback_function
         w = new_watcher(test_option)
@@ -107,8 +111,8 @@ class TestConfig(TestCase):
             print("update callback, event: {}".format(event))
 
         test_option = WatcherOptions()
-        test_option.host = "localhost"
-        test_option.port = "6379"
+        test_option.host = REDIS_HOST
+        test_option.port = REDIS_PORT
         test_option.channel = "test"
         test_option.optional_update_callback = callback_function
         w = new_watcher(test_option)
@@ -126,8 +130,8 @@ class TestConfig(TestCase):
             print("update for add policy, event: {}".format(event))
 
         test_option = WatcherOptions()
-        test_option.host = "localhost"
-        test_option.port = "6379"
+        test_option.host = REDIS_HOST
+        test_option.port = REDIS_PORT
         test_option.channel = "test"
         test_option.optional_update_callback = callback_function
         w = new_watcher(test_option)
@@ -145,8 +149,8 @@ class TestConfig(TestCase):
             print("update for remove policy callback, event: {}".format(event))
 
         test_option = WatcherOptions()
-        test_option.host = "localhost"
-        test_option.port = "6379"
+        test_option.host = REDIS_HOST
+        test_option.port = REDIS_PORT
         test_option.channel = "test"
         test_option.optional_update_callback = callback_function
         w = new_watcher(test_option)
@@ -164,8 +168,8 @@ class TestConfig(TestCase):
             print("update for remove filtered policy callback, event: {}".format(event))
 
         test_option = WatcherOptions()
-        test_option.host = "localhost"
-        test_option.port = "6379"
+        test_option.host = REDIS_HOST
+        test_option.port = REDIS_PORT
         test_option.channel = "test"
         test_option.optional_update_callback = callback_function
         w = new_watcher(test_option)
@@ -183,8 +187,8 @@ class TestConfig(TestCase):
             print("update for remove filtered policy callback, event: {}".format(event))
 
         test_option = WatcherOptions()
-        test_option.host = "localhost"
-        test_option.port = "6379"
+        test_option.host = REDIS_HOST
+        test_option.port = REDIS_PORT
         test_option.channel = "test"
         test_option.optional_update_callback = callback_function
         w = new_watcher(test_option)


### PR DESCRIPTION
I have tested with Python 3.10 and 3.9 Along with redis 5.0.1. So, putting redis>=4.5.2 means it'll accept any newer version.